### PR TITLE
feat: release v1.8.0 to nexus as a faceit artifact

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -4,9 +4,9 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.code-disaster.steamworks4j</groupId>
+	<groupId>com.faceit.steamworks4j</groupId>
 	<artifactId>steamworks4j-server</artifactId>
-	<version>1.8.1-SNAPSHOT</version>
+	<version>1.8.0</version>
 
 	<packaging>jar</packaging>
 
@@ -128,7 +128,7 @@
 		<dependency>
 			<groupId>com.code-disaster.steamworks4j</groupId>
 			<artifactId>steamworks4j</artifactId>
-			<version>1.8.1-SNAPSHOT</version>
+			<version>1.8.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
It is still safe to depend upon the 1.8.0 code-disaster steamworks4j artifact because we did not modify anything in that library, to build this successfully I had to:
1. download the steamworks sdk to `./sdk` (version was 152 when I released 1.8.0)
2. cd to `cd ./sdk/public/steam/lib/linux64` 
3. run `patchelf --set-soname libsdkencryptedappticket.so libsdkencryptedappticket.so`
3. `cd ../../../../../server` to get to the server directory
4. open up `pom.xml` and change version to `1.8.0`
5. run `mvn deploy -Plibs -DaltDeploymentRepository=faceit-nexus-private-releases-repository::default::https://nexus.faceit-infra.com/repository/maven-releases`

This will release `com.faceit.steamworks4j-server:1.8.0` to the private nexus repo, the `-Plibs` is necessary to package the `.so` library files from the sdk into the maven jar